### PR TITLE
Added configuration for commands.

### DIFF
--- a/addons/source-python/plugins/resetscore/info.py
+++ b/addons/source-python/plugins/resetscore/info.py
@@ -1,0 +1,7 @@
+## IMPORTS
+
+from plugins.manager import plugin_manager
+
+## GLOBALS
+
+info = plugin_manager.get_plugin_info(__name__)

--- a/resource/source-python/translations/resetscore.ini
+++ b/resource/source-python/translations/resetscore.ini
@@ -7,3 +7,18 @@
     en = '\x04[Resetscore] \x01Your score is already reset.'
     fr = '\x04[Resetscore] \x01Votre score a déjà été remis à zéro.'
     es = '\x04[Resetscore] \x01Tu puntuación ya esta a 0.'
+
+[Public]
+    en = """Set to the public say commands to reset player scores.
+            Separate each with a comma. Example:
+            public_commands=!rs,!resetscore"""
+
+[Private]
+    en = """Set to the private say commands to reset player scores.
+            Separate each with a comma. Example:
+            private_commands=/rs,/resetscore"""
+
+[Client]
+    en = """Set to the client commands to reset player scores.
+            Separate each with a comma. Example:
+            client_commands=rs,resetscore"""


### PR DESCRIPTION
resetscore.ini is now created if it doesn't exist to allow setting public, private, and client commands.

The command is now blocked for private and client commands. Public commands are shown in the chat area.